### PR TITLE
Api restructuring

### DIFF
--- a/doc/api-draft
+++ b/doc/api-draft
@@ -27,7 +27,7 @@ All GET requests include pagination as well as ways to filter based on the field
     * PUT: Update the post.
     * DELETE: Delete the post
 
-/post/<postid>/comments
+/post/<postid>/comment
     * GET: Get the comments related to postid.
     * POST: Add a new comment.
 

--- a/doc/api-draft
+++ b/doc/api-draft
@@ -1,6 +1,6 @@
 All GET requests include pagination as well as ways to filter based on the fields of the data model.
 
-/users
+/user
     * POST: create new user
     * GET: get a list of users.
 
@@ -9,7 +9,7 @@ All GET requests include pagination as well as ways to filter based on the field
     * PUT: update profile information
     * DELETE: Remove the user and all the associated content
 
-/blogs
+/blog
     * GET: Get a list of blogs with optional filtering.
     * POST: Add a new blog.
 
@@ -17,20 +17,21 @@ All GET requests include pagination as well as ways to filter based on the field
     * put: Update blog information
     * DELETE: Remove blog
 
-/blog/<blogid>/posts
-    * GET: Get a list of the blog's posts.
+/post
+    * GET: Get a time-sorted list of all the posts in the service.
+      - parameters: blogid
     * POST: Add a new post
 
-/blog/<blogid>/post/<postid>
+/post/<postid>
     * GET: Get the post content.
     * PUT: Update the post.
     * DELETE: Delete the post
 
-/blog/<blogid>/post/<blogid>/comments
+/post/<postid>/comments
     * GET: Get the comments related to postid.
     * POST: Add a new comment.
 
-/blog/<blogid>/post/<postid>/comment/<commentid>
+/post/<postid>/comment/<commentid>
     * GET: Get the comment data
     * PUT: Modify comment
     * DELETE: Delete comment

--- a/src/public/scripts/controllers.js
+++ b/src/public/scripts/controllers.js
@@ -96,11 +96,10 @@ angular.module('app')
     });
     $scope.addComment = function(post) {
         console.log(post);
-        var blogId = post.parent_blog;
         var postId = post._id;
         var comment = post.newComment;
         var author = $scope.currentUser;
-        Comment.addComment(blogId, postId, comment, author)
+        Comment.addComment(postId, comment, author)
             .success(function(data) {
                 console.log(data);
                 fetchPosts();

--- a/src/public/scripts/services.js
+++ b/src/public/scripts/services.js
@@ -1,12 +1,12 @@
 angular.module('app')
 .factory('Blogs', ['$http', 'ENV', function($http, ENV) {
-    return $http.get(ENV.apiEndpoint + '/blogs');
+    return $http.get(ENV.apiEndpoint + '/blog');
 }])
 
 .factory('Posts', ['$http', 'ENV', function($http, ENV) {
     return {
         fetchPosts: function(blogId) {
-            return $http.get(ENV.apiEndpoint + '/blog/'+blogId+'/posts',
+            return $http.get(ENV.apiEndpoint + '/post?blogid=' + blogId,
             { blogid: blogId});
         }
     }
@@ -15,26 +15,26 @@ angular.module('app')
 .factory('UserFeed', ['$http', 'ENV', function($http, ENV) {
     return {
         getBlogs: function(userId) {
-            return $http.get(ENV.apiEndpoint + '/blogs/'+userId);
+            return $http.get(ENV.apiEndpoint + '/blog/'+userId);
         }
     }
 }])
 
 .factory('Comment', ['$http', 'ENV', 'Session', function($http, ENV, Session) {
     return {
-        getComments : function(blogId, postId) {
-            return $http.get(ENV.apiEndpoint + '/blog/'+blogId+'/post/'+postId+'/comments');
+        getComments : function(postId) {
+            return $http.get(ENV.apiEndpoint + '/post/'+postId+'/comment');
         },
-        addComment : function(blogId, postId, comment, author) {
-            return $http.post(ENV.apiEndpoint + '/blog/'+blogId+'/post/'+postId+'/comments',
+        addComment : function(postId, comment, author) {
+            return $http.post(ENV.apiEndpoint + '/post/'+postId+'/comment',
             { comment: comment, author: author });
         },
-        updateComment : function(blogId, postId, comment) {
-            return $http.put(ENV.apiEndpoint + '/blog/'+blogId+'/post/'+postId+'/comments/'+commentId,
+        updateComment : function(postId, comment) {
+            return $http.put(ENV.apiEndpoint + '/post/'+postId+'/comment/'+commentId,
             { comment: comment });
         },
-        deleteComment : function(blogId, postId, commentId) {
-            return $http.delete(ENV.apiEndpoint + '/blog/'+blogId+'/post/'+postId+'/comments/'+commentId);
+        deleteComment : function(postId, commentId) {
+            return $http.delete(ENV.apiEndpoint + '/post/'+postId+'/comment/'+commentId);
         }
     }
 }])

--- a/src/server/comments.js
+++ b/src/server/comments.js
@@ -2,14 +2,14 @@ var mongoose = require("mongoose");
 var Post = require("./models/post");
 
 exports.getCommentsForPost = function(request, response) {
-    Post.findOne({'parent_blog': request.params.blogid, '_id': request.params.postid}, 'comments', function(err, post) {
+    Post.findOne({'_id': request.params.postid}, 'comments', function(err, post) {
         if (err) return response.send(err);
         response.json(post.comments);
     });
 };
 
 exports.addCommentToPost = function(request, response) {
-    Post.findOne({'parent_blog': request.params.blogid, '_id': request.params.postid}, 'comments', function (err, post) {
+    Post.findOne({'_id': request.params.postid}, 'comments', function (err, post) {
         if (err) return request.send(err);
         post.comments.addToSet(request.body);
         post.save(function(err) {
@@ -20,7 +20,7 @@ exports.addCommentToPost = function(request, response) {
 };
 
 exports.getComment = function(request, response) {
-    Post.findOne({'parent_blog': request.params.blogid, '_id': request.params.postid}, 'comments', function(err, post) {
+    Post.findOne({'_id': request.params.postid}, 'comments', function(err, post) {
         if(err) return response.send(err);
         comment = post.comments.id(request.params.commentid);
 
@@ -38,7 +38,7 @@ exports.updateComment = function(request, response) {
         set['comments.$.' + key] = request.body[key];
     }
 
-    Post.update({'parent_blog': request.params.blogid, '_id': request.params.postid,
+    Post.update({'_id': request.params.postid,
     'comments._id': request.params.commentid, 'comments.author': request.user_id},
     {'$set': set }, function(err) {
         if (err) return response.send(err);
@@ -47,7 +47,7 @@ exports.updateComment = function(request, response) {
 };
 
 exports.deleteComment = function(request, response) {
-    Post.findOne({'parent_blog': request.params.blogid, '_id': request.params.postid}, 'comments', function(err, post) {
+    Post.findOne({'_id': request.params.postid}, 'comments', function(err, post) {
         if(err) return response.send(err);
         comment = post.comments.id(request.params.commentid);
         // Not sure if this even works !!

--- a/src/server/posts.js
+++ b/src/server/posts.js
@@ -2,14 +2,15 @@ var mongoose = require("mongoose");
 var Post = require("./models/post");
 var Blog = require("./models/blog");
 
-exports.getPostsForBlog = function(request, response) {
-    Post.find({'parent_blog': request.params.blogid}, "-comments", function(err, posts) {
+exports.getPosts = function(request, response) {
+    Post.find({'parent_blog': request.params.blogid}, "-comments", 
+              { sort: { created_at: -1 }}, function(err, posts) {
         if (err) response.send(err);
         response.json(posts);
     });
 };
 
-exports.addPostToBlog = function(request, response) {
+exports.addPost = function(request, response) {
     request.body.parent_blog = request.params.blogid;
     post = new Post(request.body);
     post.save(function(err) {
@@ -31,7 +32,7 @@ exports.getPost = function(request, response) {
 };
 
 exports.updatePost = function(request, response) {
-    Post.update({'parent_blog': request.params.blogid, '_id': request.params.postid, 'parent_blog.author': request.user_id}, function(err, numRows) {
+    Post.update({'_id': request.params.postid, 'parent_blog.author': request.user_id}, function(err, numRows) {
         if (err) {
             return response.send(err);
         } else if (numRows == 0) {
@@ -43,7 +44,7 @@ exports.updatePost = function(request, response) {
 };
 
 exports.deletePost = function(request, response) {
-    Post.remove({'parent_blog': request.params.blogid, '_id': request.params.postid, 'parent_blog.author': request.user_id}, function(err) {
+    Post.remove({'_id': request.params.postid, 'parent_blog.author': request.user_id}, function(err) {
         if (err) return response.send(err);
         response.json({'message': 'Post deleted.'});
     });

--- a/src/server/routes.js
+++ b/src/server/routes.js
@@ -7,30 +7,30 @@ module.exports = function(app){
 
     app.post('/login', authorize.authenticate);
 
-    app.get('/blogs', blogs.getBlogs);
-    app.get('/blogs/:userid', blogs.getBlogsForUser);
+    app.get('/blog', blogs.getBlogs);
+    app.get('/blog/:userid', blogs.getBlogsForUser);
 
-    app.post('/blogs', authorize.confirmAuth, blogs.addBlog);
+    app.post('/blog', authorize.confirmAuth, blogs.addBlog);
 
     app.put('/blog/:blogid', authorize.confirmAuth, blogs.updateBlog);
     app.delete('/blog/:blogid', authorize.confirmAuth, blogs.deleteBlog);
 
-    app.get('/blog/:blogid/posts', posts.getPostsForBlog);
-    app.post('/blog/:blogid/posts', authorize.confirmAuth, posts.addPostToBlog);
+    app.get('/post', posts.getPosts);
+    app.post('/post', authorize.confirmAuth, posts.addPost);
 
-    app.get('/blog/:blogid/post/:postid', posts.getPost);
-    app.put('/blog/:blogid/post/:postid', authorize.confirmAuth, posts.updatePost);
-    app.delete('/blog/:blogid/post/:postid', authorize.confirmAuth, posts.deletePost);
+    app.get('/post/:postid', posts.getPost);
+    app.put('/post/:postid', authorize.confirmAuth, posts.updatePost);
+    app.delete('/post/:postid', authorize.confirmAuth, posts.deletePost);
 
-    app.get('/blog/:blogid/post/:postid/comments', comments.getCommentsForPost)
-    app.post('/blog/:blogid/post/:postid/comments', authorize.confirmAuth, comments.addCommentToPost);
+    app.get('/post/:postid/comment', comments.getCommentsForPost)
+    app.post('/post/:postid/comment', authorize.confirmAuth, comments.addCommentToPost);
 
-    app.get('/blog/:blogid/post/:postid/comments/:commentid', comments.getComment);
-    app.put('/blog/:blogid/post/:postid/comments/:commentid', authorize.confirmAuth, comments.updateComment);
-    app.delete('/blog/:blogid/post/:postid/comments/:commentid', authorize.confirmAuth, comments.deleteComment);
+    app.get('/post/:postid/comment/:commentid', comments.getComment);
+    app.put('/post/:postid/comments/:commentid', authorize.confirmAuth, comments.updateComment);
+    app.delete('/post/:postid/comments/:commentid', authorize.confirmAuth, comments.deleteComment);
 
-    app.get('/users', users.getUsers);
-    app.post('/users', authorize.register, users.addUser);
+    app.get('/user', users.getUsers);
+    app.post('/user', authorize.register, users.addUser);
 
     app.get('/user/:userid', users.getUser);
     app.put('/user/:userid', authorize.confirmAuth, users.updateUser);


### PR DESCRIPTION
* Unify the endpoint naming: remove separate /post and /posts, /blog and /blogs, /user and /users and stick to /blog, /post, /post/comment, /user.
* Move /blog/post to the root and retrieve the most recent posts if the blog id hasn't been given.